### PR TITLE
Explicitly list dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "react/promise": "~1",
+        "react/event-loop": "0.3.*",
         "icecave/mephisto": "0.1.*"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,9 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "a788fb0fd7a78143b0738c85935d4216",
+    "hash": "d8f3af92a21bf22161083ec8bf4cc477",
     "packages": [
         {
             "name": "eloquent/enumeration",


### PR DESCRIPTION
Currently, they're (implicitly) installed as part of a dependency of the other dependencies. IMHO this is an implementation detail that we should not rely on.

The resulting dependency graph looks like this:
![graph-composer](https://cloud.githubusercontent.com/assets/776829/3224338/b2df5aca-f031-11e3-8ff4-7cfeceb17aa0.png)
