### PR TITLE
Run tests on PHPUnit 9 and update PHPUnit configuration schema for PHPUnit 9.3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,4 +3,5 @@
 /.travis.yml export-ignore
 /examples/ export-ignore
 /phpunit.xml.dist export-ignore
+/phpunit.xml.legacy export-ignore
 /tests/ export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 # lock distro so new future defaults will not break the build
 dist: trusty
 
-matrix:
+jobs:
   include:
     - php: 5.3
       dist: precise
@@ -18,11 +18,10 @@ matrix:
     - php: hhvm-3.18
   allow_failures:
     - php: hhvm-3.18
-    
-sudo: false
 
 install:
-  - composer install --no-interaction
+  - composer install
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$TRAVIS_PHP_VERSION" > "7.2" ]]; then vendor/bin/phpunit --coverage-text; fi
+  - if [[ "$TRAVIS_PHP_VERSION" < "7.3" ]]; then vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy; fi

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.1",
-        "phpunit/phpunit": "^7.0 || ^5.0 || ^4.8"
+        "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8"
     },
     "autoload": {
         "psr-4": { "Clue\\React\\Zenity\\": "src/" }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit bootstrap="vendor/autoload.php" colors="true">
+<!-- PHPUnit configuration file with new format for PHPUnit 9.3+ -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheResult="false">
     <testsuites>
         <testsuite name="Zenity React Test Suite">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src/</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- PHPUnit configuration file with old format for PHPUnit 9.2 or older -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/4.8/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Zenity React Test Suite">
+            <directory>./tests/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>./src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/FunctionalLauncherTest.php
+++ b/tests/FunctionalLauncherTest.php
@@ -13,7 +13,10 @@ class FunctionalLauncherTest extends TestCase
     private $dialog;
     private $launcher;
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpLauncher()
     {
         $this->loop = Factory::create();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -44,7 +44,13 @@ class TestCase extends BaseTestCase
      */
     protected function createCallableMock()
     {
-        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        if (method_exists('PHPUnit\Framework\MockObject\MockBuilder', 'addMethods')) {
+            // PHPUnit 9+
+            return $this->getMockBuilder('stdClass')->addMethods(array('__invoke'))->getMock();
+        } else {
+            // legacy PHPUnit 4 - PHPUnit 8
+            return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+        }
     }
 
     protected function expectPromiseResolve($promise)

--- a/tests/Zen/BaseZenTest.php
+++ b/tests/Zen/BaseZenTest.php
@@ -11,7 +11,10 @@ abstract class BaseZenTest extends TestCase
     protected $process;
     protected $stdin = '';
 
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpMocks()
     {
         $inbuffer =& $this->stdin;
         $this->instream = $this->getMockBuilder('React\Stream\WritableStreamInterface')->getMock();

--- a/tests/Zen/FunctionalBaseZenTest.php
+++ b/tests/Zen/FunctionalBaseZenTest.php
@@ -8,7 +8,10 @@ use Clue\Tests\React\Zenity\TestCase;
 
 class FunctionalBaseZenTest extends TestCase
 {
-    public function setUp()
+    /**
+     * @before
+     */
+    public function setUpLoop()
     {
         $this->loop = Factory::create();
     }


### PR DESCRIPTION
PHPUnit 9.3 released a new schema for the `phpunit.xml` configuration file. I had to migrate the file to the new format in order to avoid the warning. PHPUnit Versions older than 9.3 have to use the `phpunit.xml.legacy` configuration file, because the new format is unknown for them.
For further details concerning this pull request look into https://github.com/graphp/graphviz/pull/46.

Together with #57 (by @SimonFrings, one handsome guy) it's also possible to run this code with PHP 8 🎉
 ```bash
$ docker run -it --rm -v `pwd`:/data --workdir=/data php:8.0.0beta2-cli php vendor/bin/phpunit
PHPUnit 9.3.11 by Sebastian Bergmann and contributors.

...............................................................  63 / 110 ( 57%)
...............................................                 110 / 110 (100%)

Time: 00:00.349, Memory: 8.00 MB

OK (110 tests, 324 assertions)
```