### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": ">=5.3",
-        "react/child-process": "^0.6 || ^0.5 || ^0.4 || ^0.3",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/child-process": "^0.6.3",
+        "react/event-loop": "^1.2",
         "react/promise": "~2.0|~1.0"
     },
     "require-dev": {

--- a/examples/01-dialog.php
+++ b/examples/01-dialog.php
@@ -1,6 +1,5 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Dialog\InfoDialog;
 use Clue\React\Zenity\Dialog\QuestionDialog;
@@ -10,9 +9,7 @@ use Clue\React\Zenity\Dialog\WarningDialog;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 
 $q = new EntryDialog('What\'s your name?');
 $q->setEntryText(getenv('USER'));
@@ -29,5 +26,3 @@ $launcher->launch($q)->then(function ($name) use ($launcher) {
 }, function () use ($launcher) {
     $launcher->launch(new WarningDialog('No name given'));
 });
-
-$loop->run();

--- a/examples/02-file.php
+++ b/examples/02-file.php
@@ -1,6 +1,5 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Dialog\FileSelectionDialog;
 use Clue\React\Zenity\Builder;
@@ -8,9 +7,7 @@ use Clue\React\Zenity\Dialog\InfoDialog;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 $builder = new Builder();
 
 $launcher->launch($builder->fileSelection())->then(function (SplFileInfo $file) use ($launcher) {
@@ -26,5 +23,3 @@ $launcher->launch($builder->fileSelection())->then(function (SplFileInfo $file) 
         $launcher->launch($selection);
     });
 });
-
-$loop->run();

--- a/examples/03-progress-pulsate.php
+++ b/examples/03-progress-pulsate.php
@@ -1,14 +1,12 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Builder;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 $builder = new Builder();
 
 $progress = $launcher->launchZen($builder->pulsate('Pseudo-processing...'));
@@ -24,7 +22,7 @@ $texts = array(
     'Finishing'
 );
 
-$timer = $loop->addPeriodicTimer(2.0, function ($timer) use ($progress, $texts) {
+$timer = Loop::addPeriodicTimer(2.0, function ($timer) use ($progress, $texts) {
     static $i = 0;
 
     if (isset($texts[$i])) {
@@ -48,5 +46,3 @@ $progress->promise()->then(null, function() use ($timer, $builder, $launcher) {
 
     $launcher->launch($builder->error('Canceled'));
 });
-
-$loop->run();

--- a/examples/04-progress-random.php
+++ b/examples/04-progress-random.php
@@ -1,21 +1,19 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Builder;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 $builder = new Builder();
 
 $progress = $launcher->launchZen($builder->progress('Pseudo-processing...'));
 
 $progress->setPercentage(50);
 
-$timer = $loop->addPeriodicTimer(0.2, function () use ($progress) {
+$timer = Loop::addPeriodicTimer(0.2, function () use ($progress) {
     $progress->advance(mt_rand(-1, 3));
 });
 
@@ -29,5 +27,3 @@ $progress->promise()->then(
         $timer->cancel();
     }
 );
-
-$loop->run();

--- a/examples/05-form.php
+++ b/examples/05-form.php
@@ -1,13 +1,11 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Dialog\FormsDialog;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 
 $form = new FormsDialog();
 $form->setWindowIcon('info');
@@ -25,5 +23,3 @@ $launcher->launch($form)->then(function($result) {
 }, function() {
     var_dump('form canceled');
 });
-
-$loop->run();

--- a/examples/06-menu.php
+++ b/examples/06-menu.php
@@ -1,15 +1,12 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Builder;
 use Clue\React\Zenity\Dialog\InfoDialog;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 $builder = new Builder();
 
 $main = function() use (&$main, $builder, $launcher) {
@@ -53,5 +50,3 @@ $main = function() use (&$main, $builder, $launcher) {
 };
 
 $main();
-
-$loop->run();

--- a/examples/10-notification.php
+++ b/examples/10-notification.php
@@ -1,14 +1,12 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Builder;
+use React\EventLoop\Loop;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 $builder = new Builder();
 
 $notification = $builder->notifier();
@@ -17,11 +15,9 @@ $zen = $launcher->launchZen($notification);
 $zen->setMessage('Hello world');
 
 $n = 0;
-$loop->addPeriodicTimer(10.0, function ($timer) use ($zen, &$n) {
+Loop::addPeriodicTimer(10.0, function ($timer) use ($zen, &$n) {
     static $icons = array('error', 'warning', 'info', '');
     $zen->setIcon($icons[array_rand($icons)]);
 
     $zen->setMessage('Hi' . ++$n);
 });
-
-$loop->run();

--- a/examples/20-blocking.php
+++ b/examples/20-blocking.php
@@ -1,15 +1,12 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\Zenity\Launcher;
 use Clue\React\Zenity\Builder;
 use Clue\React\Zenity\Dialog\EntryDialog;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
-
-$launcher = new Launcher($loop);
+$launcher = new Launcher();
 $builder = new Builder();
 
 $name = $launcher->waitFor(new EntryDialog('Search package'));

--- a/src/Launcher.php
+++ b/src/Launcher.php
@@ -2,6 +2,7 @@
 
 namespace Clue\React\Zenity;
 
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use Clue\React\Zenity\Dialog\AbstractDialog;
 use React\Promise\Deferred;
@@ -14,11 +15,17 @@ use React\ChildProcess\Process;
  */
 class Launcher
 {
+    /** @var LoopInterface */
     private $loop;
+
     private $processLauncher;
     private $bin = 'zenity';
 
-    public function __construct(LoopInterface $loop, $processLauncher = null)
+    /**
+     * @param ?LoopInterface $loop
+     * @param ?Callable $processLauncher
+     */
+    public function __construct(LoopInterface $loop = null, $processLauncher = null)
     {
         if ($processLauncher === null) {
             $processLauncher = function ($cmd) {
@@ -26,8 +33,8 @@ class Launcher
             };
         }
 
+        $this->loop = $loop ?: Loop::get();
         $this->processLauncher = $processLauncher;
-        $this->loop = $loop;
     }
 
     public function setBin($bin)

--- a/tests/LauncherTest.php
+++ b/tests/LauncherTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Clue\Tests\React\Zenity;
+
+use Clue\React\Zenity\Launcher;
+
+class LauncherTest extends TestCase
+{
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $launcher = new Launcher();
+
+        $ref = new \ReflectionProperty($launcher, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($launcher);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+}

--- a/tests/Zen/BaseZenTest.php
+++ b/tests/Zen/BaseZenTest.php
@@ -1,8 +1,6 @@
 <?php
 
 use Clue\React\Zenity\Zen\BaseZen;
-use React\EventLoop\Factory;
-use React\ChildProcess\Process;
 use Clue\Tests\React\Zenity\TestCase;
 
 abstract class BaseZenTest extends TestCase


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$launcher = new Clue\React\Zenity\Launcher($loop);

// new (using default loop)
$launcher = new Clue\React\Zenity\Launcher();
```
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229, reactphp/event-loop#232 and reactphp/child-process#87