### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@
 
 * BC break: Move launching logic from `Dialog` to `Launcher`
   (#11)
-  * The `Dialog` now reprents the dialog option setup, the `Launcher` represents a running instance (process) of the given dialog setup. Clear distinction between setup and the actual process.
+  * The `Dialog` now represents the dialog option setup, the `Launcher` represents a running instance (process) of the given dialog setup. Clear distinction between setup and the actual process.
   * Running a single `Dialog` setup multiple times or changing settings after launching the first instance is now handled gracefully.
   * Simplified `Builder` and `Dialog` constructors to no longer require a `Launcher` instance.
   * Moved `Dialog::run()` to `Launcher::launch($dialog)`

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ For anything more complex, you can also instantiate the below classes directly.
 ### Dialog
 
 The `Dialog` API is modelled closely after Zenity's command line API, so it should be
-familar if you're already using it from within any other command line script.
+familiar if you're already using it from within any other command line script.
 
 #### AbstractDialog
 
@@ -317,7 +317,7 @@ On Debian- and Ubuntu-based distributions you can make sure it's installed like 
 $ sudo apt-get install zenity
 ```
 
-Otherwise you may have to install Zenity yourself (use your favorite search engine, download the appropriate realease tarball or compile from soure).
+Otherwise you may have to install Zenity yourself (use your favorite search engine, download the appropriate release tarball or compile from source).
 Zenity it not officially supported on other platforms, however several non-official releases exist.
 
 *Running on [Windows is currently not supported](https://github.com/reactphp/child-process/issues/9)*

--- a/src/Dialog/NotificationDialog.php
+++ b/src/Dialog/NotificationDialog.php
@@ -17,7 +17,7 @@ class NotificationDialog extends AbstractTextDialog
     /**
      * Listens for commands at standard input.
      *
-     * At least one command must be specified. Commands are comma seperated.
+     * At least one command must be specified. Commands are comma separated.
      * A command must be followed by a colon and a value.
      *
      * @param unknown $listen

--- a/src/Dialog/PasswordDialog.php
+++ b/src/Dialog/PasswordDialog.php
@@ -21,7 +21,7 @@ use Clue\React\Zenity\Zen\PasswordZen;
  * there's no way to reliably tell where the username ends and the password
  * starts in a string like "user|name|pass|word". Because it's common to have
  * special characters in the password and usernames tend to be restricted, this
- * library assumes the username ends after the first occurance:
+ * library assumes the username ends after the first occurrence:
  * <code>
  * $ret = array('user', 'name|pass|word');
  * </code>


### PR DESCRIPTION
This pull request fixes a few typos with the help of https://github.com/szepeviktor/typos-on-you.

Builds on top of https://github.com/clue/reactphp-redis/pull/146.